### PR TITLE
Fix a bug that prevents bookmarks from being stored

### DIFF
--- a/src/store/syncedActions.ts
+++ b/src/store/syncedActions.ts
@@ -14,6 +14,7 @@ type completeBookStateActionNames = `bookState/${bookStateActionNames}`
 
 export default new Set<completeAppStateActionNames|completeBookStateActionNames>([
   "bookState/AddHighlight",
+  "bookState/ToggleBookmark",
   "bookState/ChangeHighlightColor",
   "bookState/ChangeHighlightNote",
   "bookState/DeleteHighlight",


### PR DESCRIPTION
The `bookState/ToggleBookmark` action is not in `syncedActions`, which prevents bookmarks from being persisted.