### PR TITLE
Adding MacOS build to Alexandria

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -10,7 +10,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          platform: [windows-latest, ubuntu-20.04] # [macos-latest, ubuntu-20.04, windows-latest]
+          platform: [windows-latest, ubuntu-20.04, macos-latest] # [macos-latest, ubuntu-20.04, windows-latest]
       runs-on: ${{ matrix.platform }}
       steps:
         - uses: actions/checkout@v4
@@ -28,7 +28,12 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
             sudo apt-get install -y clang autoconf libtool
-            cd ./libmobi-rs && sh build.sh
+            cd ./libmobi-rs && sh build-linux.sh
+        - name: install dependencies (macOS only)
+          if: matrix.platform == 'macos-latest'
+          run: |
+            brew install automake autoconf libtool
+            cd ./libmobi-rs && sh build-mac.sh
         - name: install frontend dependencies
           run: npm install # change this to npm or pnpm depending on which one you use
         - uses: tauri-apps/tauri-action@v0
@@ -41,5 +46,6 @@ jobs:
               src-tauri/target/release/**/*.msi
               src-tauri/target/release/**/*.deb
               src-tauri/target/release/**/*.AppImage
+              src-tauri/target/release/**/*.dmg
               !src-tauri/target/release/deps
               !src-tauri/target/release/build

--- a/docs/Build Instructions.md
+++ b/docs/Build Instructions.md
@@ -36,7 +36,7 @@ First make sure dependencies are present:
 Then run the install script
 
 1. `cd libmobi-rs`
-2. `sh ./build.sh`
+2. `sh ./build-linux.sh`
 
 The static library will be tested in a minimal rust environment. If this unit test passes, you are clear to proceed with the final step. 
 


### PR DESCRIPTION
This PR resolves #18 .

 - Changed libmobi-rs to include MacOS's Libmobi library as well
 - Added MacOS build instructions to GitHub actions

Testing:

- Tested locally using act
- Tested on my forked's main GitHub actions.

---

This PR is not complete though because MacOS build artifacts (.dmg file) need to be signed by the developer to be shown as a legit app by Mac. If not, the dmg file when opened, gives you a warning saying that this is from an unidentified developer (you can circumvent it though)

[Tauri's official documentation](https://tauri.app/v1/guides/distribution/sign-macos/) has instructions on how to sign MacOS apps.

Also, the Build instructions are not fully updated with Mac instructions. I shall make the changes after @btpf decides on how to move forward with Code signing/ if he doesn't want to support MacOS now....
