### PR TITLE
Delay loading of `percentageFromCfi` until `displayedCFI` is ready.

### DIFF
--- a/src/routes/Reader/ProgressMenu/ProgressMenu.tsx
+++ b/src/routes/Reader/ProgressMenu/ProgressMenu.tsx
@@ -106,7 +106,11 @@ const ProgressInfoBar = ()=>{
     }
 
   }
-
+  
+  // wait until displayedCFI is loaded
+  if (!displayedCFI) {
+    return <BottomMenuContainer active={menuActive}></BottomMenuContainer>;
+  }
   const currentPercentage = renditionInstance?.book.locations.percentageFromCfi(displayedCFI)
   
   const locationsCount = renditionInstance?.book.locations.total

--- a/src/routes/Reader/Reader.tsx
+++ b/src/routes/Reader/Reader.tsx
@@ -196,7 +196,7 @@ const Home = () =>{
         <div onClick={()=>{
           dispatch(ToggleProgressMenu())
         }} className={styles.percentageContainer}>
-          {renditionInstance? Math.round(renditionInstance.book.locations.percentageFromCfi(displayedCFI)*100):"0"}%
+          {displayedCFI && renditionInstance? Math.round(renditionInstance.book.locations.percentageFromCfi(displayedCFI)*100):"0"}%
         </div>
         <div className={styles.sliderContainer}>
           <SliderNavigator/>


### PR DESCRIPTION
When loading a `.txt` file, I observed that `percentageFromCfi` is invoked with `displayedCFI` before `displayedCFI` is fully initialized. This premature loading can cause issues similar to those reported in #47.

### Changes
- Added a check to ensure displayedCFI is loaded before invoking percentageFromCfi.